### PR TITLE
Fix phone type and rename is_possible

### DIFF
--- a/app/src/phone_normalizer_service/normalizer/functions.py
+++ b/app/src/phone_normalizer_service/normalizer/functions.py
@@ -266,7 +266,7 @@ def format_mx_number(nir, local_number):
     line = local_number[-4:]
     normphone['urban'] = serie
     normphone['line'] =  line
-    normphone['type'] = '0'
+    normphone['type'] = 0
 
     listCodes = NumGeoMx.objects.filter(nir=nir,serie=serie,numeracion_inicial__lte=line, numeracion_final__gte=line)
     if listCodes.exists():

--- a/app/src/phone_normalizer_service/normalizer/views.py
+++ b/app/src/phone_normalizer_service/normalizer/views.py
@@ -73,7 +73,7 @@ def geo(request):
                 urbano = parse_number['urban']
                 linea = parse_number['line']
                 local_number = parse_number['urban'] + parse_number['line']
-                is_posible = True if number_type != PhoneNumberType.UNKNOWN else False
+                is_possible = True if number_type != PhoneNumberType.UNKNOWN else False
                 dial_number = phonenumbers.format_number(phonenumbers.parse('+' + country_code + national_number, None), phonenumbers.PhoneNumberFormat.E164)
 
             else:
@@ -87,7 +87,7 @@ def geo(request):
                 country = geocoder.country_name_for_number(parse_number, 'EN')
                 country_iata = region_code_for_number(parse_number)
                 tmpcarrier = carrier.name_for_valid_number(parse_number, 'EN')
-                is_posible = phonenumbers.is_possible_number(parse_number)
+                is_possible = phonenumbers.is_possible_number(parse_number)
                 urbano = ''
                 linea = ''
                 mobile_code = ''
@@ -115,7 +115,7 @@ def geo(request):
                     linea = parse_mx_number['line']
                     number_type = parse_mx_number['type']
 
-            if is_posible:
+            if is_possible:
                 res = {
                     'is_valid': is_valid,
                     'location': location,
@@ -126,7 +126,7 @@ def geo(request):
                     'dial_number': dial_number,
                     'urban': urbano,
                     'line': linea,
-                    'is_posible': is_posible,
+                    'is_possible': is_possible,
                     'ori_number': number,
                     'number_data': {
                         'CC': country_code,


### PR DESCRIPTION
## Summary
- normalize type as integer in `format_mx_number`
- correct misspelling `is_posible` in `views`

## Testing
- `python3 -m pip install Django==2.2.12 django-import-export==2.0.2 phonenumbers==8.12.1 pytz==2019.3`
- `python3 app/src/phone_normalizer_service/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686bd135417c83269464d301cc347c11